### PR TITLE
Fix a crash when running in Ardour 5

### DIFF
--- a/src/dexed.cpp
+++ b/src/dexed.cpp
@@ -801,7 +801,7 @@ uint8_t Dexed::getEngineType() {
 void Dexed::setEngineType(uint8_t tp) {
     TRACE("settings engine %d", tp);
 
-    if(engineType==tp)
+    if(engineType==tp && controllers.core!=NULL)
       return;
 
     switch (tp)  {


### PR DESCRIPTION
The current code contains a check that avoids setting the current
FM engine if the engine type is the same as the one that's already
set. The problem is that if the target engine type is `0` and the
current engine has never been set, the engine will never be set.
This leads to a NULL pointer dereference when the engine is accessed
later during rendering.

The fix is to change the logic slightly so that the set operation
isn't avoided if the current core is NULL.