### PR TITLE
Fix bank definitions.

### DIFF
--- a/src/manifest.ttl
+++ b/src/manifest.ttl
@@ -13,42 +13,42 @@
     rdfs:seeAlso <modgui.ttl> .
 
 <https://github.com/dcoredump/dexed.lv2#ROM1A>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM1A" .
 
 <https://github.com/dcoredump/dexed.lv2#ROM1B>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM1B" .
 
 <https://github.com/dcoredump/dexed.lv2#ROM2A>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM2A" .
 
 <https://github.com/dcoredump/dexed.lv2#ROM2B>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM2B" .
 
 <https://github.com/dcoredump/dexed.lv2#ROM3A>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM3A" .
 
 <https://github.com/dcoredump/dexed.lv2#ROM3B>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM3B" .
 
 <https://github.com/dcoredump/dexed.lv2#ROM4A>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM4A" .
 
 <https://github.com/dcoredump/dexed.lv2#ROM4B>
-	a pset:bank ;
+	a pset:Bank ;
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
 	rdfs:label "ROM4B" .
 

--- a/src/user-presets/dexed-DCDCollection.lv2/manifest.ttl
+++ b/src/user-presets/dexed-DCDCollection.lv2/manifest.ttl
@@ -8,7 +8,7 @@
 
 <dexed-DCDCollection>
 	lv2:appliesTo <https://github.com/dcoredump/dexed.lv2> ;
-	a pset:bank ;
+	a pset:Bank ;
 	rdfs:label "DCDCollection" .
 
 <dexed-01_FM-Rhodes.ttl>


### PR DESCRIPTION
Replace "a pset:bank" by "a pset:Bank" in bank declarations (class name), according to LV2 specification.